### PR TITLE
Updating Pavement to add support for Windows run

### DIFF
--- a/pavement.py
+++ b/pavement.py
@@ -1,6 +1,6 @@
 from paver.easy import *
 from paver.setuputils import setup
-import multiprocessing , threading , os
+import threading , os
 
 setup(
     name = "behave-browserstack",
@@ -31,7 +31,9 @@ def run(args):
             p = threading.Thread(target=run_behave_test,args=(args[0], "single",i))
             jobs.append(p)
             p.start()
-        p.join()
+            
+        for th in jobs:
+         th.join()
 
 @task
 def test():

--- a/pavement.py
+++ b/pavement.py
@@ -15,7 +15,7 @@ setup(
 )
 
 def run_behave_test(config, feature, task_id=0):
-    if(platform.system()== 'Windows'):
+    if platform.system() == 'Windows':
         sh('SET CONFIG_FILE=config/%s.json & SET TASK_ID=%s & behave features/%s.feature' % (config, task_id, feature))
     else:
         sh('export CONFIG_FILE=config/%s.json && export TASK_ID=%s && behave features/%s.feature' % (config, task_id, feature))

--- a/pavement.py
+++ b/pavement.py
@@ -15,7 +15,7 @@ setup(
 )
 
 def run_behave_test(config, feature, task_id=0):
-    os.environ['CONFIG_FILE'] = 'config/'+config+'.json'
+    os.environ['CONFIG_FILE'] = 'config/{}.json'.format(config)
     os.environ['TASK_ID'] = str(task_id)
     sh('behave features/%s.feature' % (feature))
 

--- a/pavement.py
+++ b/pavement.py
@@ -17,7 +17,7 @@ setup(
 def run_behave_test(config, feature, task_id=0):
     os.environ['CONFIG_FILE'] = 'config/{}.json'.format(config)
     os.environ['TASK_ID'] = str(task_id)
-    sh('behave features/%s.feature' % (feature))
+    sh('behave features/{}.feature'.format(feature))
 
 @task
 @consume_nargs(1)

--- a/pavement.py
+++ b/pavement.py
@@ -1,6 +1,6 @@
 from paver.easy import *
 from paver.setuputils import setup
-import threading , os
+import threading, os, platform
 
 setup(
     name = "behave-browserstack",
@@ -15,9 +15,10 @@ setup(
 )
 
 def run_behave_test(config, feature, task_id=0):
-    os.environ['CONFIG_FILE'] = 'config/{}.json'.format(config)
-    os.environ['TASK_ID'] = str(task_id)
-    sh('behave features/{}.feature'.format(feature))
+    if(platform.system()== 'Windows'):
+        sh('SET CONFIG_FILE=config/%s.json & SET TASK_ID=%s & behave features/%s.feature' % (config, task_id, feature))
+    else:
+        sh('export CONFIG_FILE=config/%s.json && export TASK_ID=%s && behave features/%s.feature' % (config, task_id, feature))
 
 @task
 @consume_nargs(1)
@@ -31,7 +32,7 @@ def run(args):
             p = threading.Thread(target=run_behave_test,args=(args[0], "single",i))
             jobs.append(p)
             p.start()
-            
+
         for th in jobs:
          th.join()
 

--- a/pavement.py
+++ b/pavement.py
@@ -31,6 +31,7 @@ def run(args):
             p = threading.Thread(target=run_behave_test,args=(args[0], "single",i))
             jobs.append(p)
             p.start()
+        p.join()
 
 @task
 def test():

--- a/pavement.py
+++ b/pavement.py
@@ -1,6 +1,6 @@
 from paver.easy import *
 from paver.setuputils import setup
-import multiprocessing
+import multiprocessing , threading , os
 
 setup(
     name = "behave-browserstack",
@@ -15,7 +15,9 @@ setup(
 )
 
 def run_behave_test(config, feature, task_id=0):
-    sh('CONFIG_FILE=config/%s.json TASK_ID=%s behave features/%s.feature' % (config, task_id, feature))
+    os.environ['CONFIG_FILE'] = 'config/'+config+'.json'
+    os.environ['TASK_ID'] = str(task_id)
+    sh('behave features/%s.feature' % (feature))
 
 @task
 @consume_nargs(1)
@@ -26,7 +28,7 @@ def run(args):
     else:
         jobs = []
         for i in range(4):
-            p = multiprocessing.Process(target=run_behave_test, args=(args[0], "single", i))
+            p = threading.Thread(target=run_behave_test,args=(args[0], "single",i))
             jobs.append(p)
             p.start()
 


### PR DESCRIPTION
Updating to solve Windows parallel run issue works on Windows,Mac and Linux.

The Issue is run_behave_test function, you have set CONFIG_FILE and TASK_ID to Environment variable and windows was not consuming the same way Mac does, so changed it to use os package and set it as environment variable.